### PR TITLE
fix(deep-research): improve report rendering and search result interactions

### DIFF
--- a/packages/ChatMessage/src/components/DeepResearch/DeepResearchDrawer.tsx
+++ b/packages/ChatMessage/src/components/DeepResearch/DeepResearchDrawer.tsx
@@ -107,14 +107,16 @@ export const DeepResearchDrawer = ({
               <div className="flex items-center gap-2">
                 {activeTab === t("deepResearch.tab.report") && (
                   <>
-                    <button
-                      type="button"
-                      className="flex items-center gap-1 px-2 py-1 rounded-full bg-[#E9F0FE] dark:bg-blue-900/30 text-sm text-[#1784FC] dark:text-blue-400 hover:bg-[#E0E9FD] dark:hover:bg-blue-900/50 border-none outline-none cursor-pointer"
-                      onClick={() => reportData?.url && window.open(formatUrl?.({ url: reportData.url }) || reportData.url, '_blank')}
+                    <a
+                      className="flex items-center gap-1 px-2 py-1 rounded-full bg-[#E9F0FE] dark:bg-blue-900/30 text-sm text-[#1784FC] dark:text-blue-400 hover:bg-[#E0E9FD] dark:hover:bg-blue-900/50 border-none outline-none cursor-pointer no-underline"
+                      href={reportData?.url ? (formatUrl?.({ url: reportData.url }) || reportData.url) : undefined}
+                      download={reportData?.title || true}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       <Download className="w-4 h-4" />
                       <span>{t("deepResearch.button.download")}</span>
-                    </button>
+                    </a>
                     <button
                       type="button"
                       className="flex items-center gap-1 px-2 py-1 rounded-full bg-[#E9F0FE] dark:bg-blue-900/30 text-sm text-[#1784FC] dark:text-blue-400 hover:bg-[#E0E9FD] dark:hover:bg-blue-900/50 border-none outline-none cursor-pointer"

--- a/packages/ChatMessage/src/components/DeepResearch/ResearchReportContent.tsx
+++ b/packages/ChatMessage/src/components/DeepResearch/ResearchReportContent.tsx
@@ -9,6 +9,7 @@ export interface ResearchReportData {
   url?: string;
   created?: string;
   attachment?: string;
+  format?: string;
 }
 
 export interface ResearchReportContentProps {
@@ -68,15 +69,35 @@ export const ResearchReportContent = ({
         </div>
       )}
       {content && (
-        <div className="cm-markdown">
-          <Markdown content={content} />
-        </div>
+        data?.format === "html" ? (
+          <iframe
+            srcDoc={content}
+            className="w-full border-0 rounded-lg"
+            style={{ minHeight: 600 }}
+            sandbox="allow-same-origin"
+            title="research-report"
+          />
+        ) : (
+          <div className="cm-markdown">
+            <Markdown content={content} />
+          </div>
+        )
       )}
 
-      {data?.url && (
-        <div className="cm-markdown">
-          <Markdown url={formatUrl ? formatUrl({ url: data.url }) : data.url} />
-        </div>
+      {!content && data?.url && (
+        data?.format === "html" ? (
+          <iframe
+            src={formatUrl ? formatUrl({ url: data.url }) : data.url}
+            className="w-full border-0 rounded-lg"
+            style={{ minHeight: 600 }}
+            sandbox="allow-same-origin allow-scripts"
+            title="research-report"
+          />
+        ) : (
+          <div className="cm-markdown">
+            <Markdown url={formatUrl ? formatUrl({ url: data.url }) : data.url} />
+          </div>
+        )
       )}
     </div>
   );

--- a/packages/ChatMessage/src/components/DeepResearch/ResearchSearchResultsContent.tsx
+++ b/packages/ChatMessage/src/components/DeepResearch/ResearchSearchResultsContent.tsx
@@ -63,7 +63,7 @@ export const ResearchSearchResultsContent = ({
         theme={theme || "light"}
         hideHeader
         onRecordClick={(record) => {
-          if (typeof record.url === "string") window.open(record.url);
+          if (typeof record.url === "string") window.open(record.url, "_blank");
         }}
       />
     </div>


### PR DESCRIPTION
## Summary

Fix several issues in the Deep Research drawer UI.

## Changes

### `ResearchReportContent`
- Add `format` field to `ResearchReportData` interface
- Render HTML reports via `<iframe>` (`srcDoc` for inline content, `src` for URL-based), Markdown for other formats
- Guard URL-based rendering to only show when no inline `content` is present (avoids duplicate display)

### `DeepResearchDrawer`
- Replace download `<button>` + `window.open` with `<a download>` so the report file is actually saved locally instead of opening in a new tab

### `ResearchSearchResultsContent`
- Pass `'_blank'` to `window.open` so search result URLs open in a new tab correctly