### PR TITLE
feat: support deep research history replay and fix send-blank

### DIFF
--- a/packages/AIChat/src/components/Chat.tsx
+++ b/packages/AIChat/src/components/Chat.tsx
@@ -218,6 +218,7 @@ const InnerChatAI = memo(
             if (chunkData.chunk_type) {
               // 标记回复开始
               if (chunkData.chunk_type === "reply_start") {
+                activeMessageRef.current?.reset(); // 收到新回复后再清空上一条，避免发送期间屏幕空白
                 setCurChatEnd(false);
               }
 
@@ -346,8 +347,6 @@ const InnerChatAI = memo(
           setQuestion(text);
 
           await fetchHistory(chat._id);
-
-          activeMessageRef.current?.reset();
 
           const queryParams = {
             search:

--- a/packages/ChatMessage/src/components/DeepResearch/index.tsx
+++ b/packages/ChatMessage/src/components/DeepResearch/index.tsx
@@ -14,6 +14,7 @@ import type { ResearchReportData } from "./ResearchReportContent";
 import type { IChunkData } from "../../types/chat";
 
 interface DeepResearchProps {
+  Detail?: { type: string; payload?: IChunkData[] };
   ChunkData?: IChunkData[];
   question?: string;
   formatUrl?: (data: any) => string;
@@ -215,6 +216,7 @@ const deriveDeepResearchState = (chunks: IChunkData[]): DeepResearchState => {
 };
 
 export const DeepResearch = ({
+  Detail,
   ChunkData = [],
   question,
   formatUrl,
@@ -225,6 +227,14 @@ export const DeepResearch = ({
   const [drawerDefaultTab, setDrawerDefaultTab] = useState(
     t("deepResearch.tab.steps"),
   );
+
+  // Merge persisted detail chunks (from ES history) with live streaming chunks.
+  // Detail.payload contains the saved chunks; ChunkData contains real-time ones.
+  const allChunks = useMemo(() => {
+    const saved = Detail?.payload ?? [];
+    if (ChunkData.length > 0) return ChunkData;
+    return saved;
+  }, [Detail?.payload, ChunkData]);
 
   const {
     deepResearchPlans,
@@ -238,7 +248,7 @@ export const DeepResearch = ({
     deepResearchReporterFinished,
     deepResearchReportData,
     deepResearchSearchMap,
-  } = useMemo(() => deriveDeepResearchState(ChunkData), [ChunkData]);
+  } = useMemo(() => deriveDeepResearchState(allChunks), [allChunks]);
 
   const hasDeepResearchPlan =
     deepResearchPlans.length > 0 &&

--- a/packages/ChatMessage/src/components/index.tsx
+++ b/packages/ChatMessage/src/components/index.tsx
@@ -331,6 +331,7 @@ const InnerChatMessage = memo(
           <PayloadCard payload={payload as any} formatUrl={formatUrl} />
 
           <DeepResearch
+            Detail={details.find((item) => item.type === "deep_research")}
             ChunkData={deepResearch}
             question={question}
             formatUrl={formatUrl}


### PR DESCRIPTION
## Changes

### DeepResearch History Replay
- **DeepResearch component**: Add `Detail` prop to accept persisted chunks from Elasticsearch history
- **DeepResearch component**: Merge saved chunks with live streaming data (prefer live when available)
- **ChatMessage**: Pass `Detail` (type=`deep_research`) to `DeepResearch` component for history replay

### Fix: Blank Screen During Message Send
- **Chat**: Defer `reset()` from `sendMessage` to `reply_start` chunk handler
- Previously, the active message area was cleared immediately when sending, causing a blank screen while waiting for the API response
- Now the previous content stays visible until the backend starts streaming the new reply

## Related
- Backend changes in `infini.sh/coco` (separate repo): persist deep research v2 chunks as `ProcessingDetails` (type=`deep_research`) on the reply `ChatMessage`